### PR TITLE
Man man syntax tests fail gracefully if man version is not suitable.

### DIFF
--- a/tests/mansyntax.sh
+++ b/tests/mansyntax.sh
@@ -13,7 +13,8 @@ mandir=${srcdir}/../docs
 # Only test if suitable man is available
 #
 if ! man --help | grep -q warnings; then
-  exit 77
+  echo "man version not suitable, skipping tests"
+  exit 0
 fi
 
 ec=0


### PR DESCRIPTION
This should fix the test failures on MacOS X.
